### PR TITLE
docs: add MSRV badge and fix badge ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 
 [![Crates.io](https://img.shields.io/crates/v/openai-ergonomic.svg)](https://crates.io/crates/openai-ergonomic)
 [![Documentation](https://docs.rs/openai-ergonomic/badge.svg)](https://docs.rs/openai-ergonomic)
+[![CI](https://github.com/genai-rs/openai-ergonomic/workflows/CI/badge.svg)](https://github.com/genai-rs/openai-ergonomic/actions)
+[![MSRV](https://img.shields.io/badge/MSRV-1.82-blue)](https://blog.rust-lang.org/2024/10/17/Rust-1.82.0.html)
 [![License](https://img.shields.io/crates/l/openai-ergonomic.svg)](https://github.com/genai-rs/openai-ergonomic#license)
-[![Build Status](https://github.com/genai-rs/openai-ergonomic/workflows/CI/badge.svg)](https://github.com/genai-rs/openai-ergonomic/actions)
 
 Ergonomic Rust wrapper for the OpenAI API, providing type-safe builder patterns and async/await support.
 


### PR DESCRIPTION
## Summary
- Add missing MSRV badge (1.82) to match langfuse-ergonomic patterns
- Fix badge ordering to match langfuse-ergonomic: Crates.io, Documentation, CI, MSRV, License
- Update CI badge text from "Build Status" to "CI"

## Changes
- Added MSRV badge linking to Rust 1.82.0 release notes
- Reordered badges to maintain consistency across genai-rs projects
- Updated CI badge label for clarity

🤖 Generated with [Claude Code](https://claude.ai/code)