### PR TITLE
fix: update docs agent to work headless without GUI programs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,11 @@
 - **Scope**: README, docs.rs comments, `docs/` guides, examples.
 - **Inputs**: Feature notes, diffs from implementation agents, documentation gaps flagged in TODO.
 - **Outputs**: Updated README sections, new examples, expanded documentation, doctest coverage.
+- **Headless Operation**:
+  - Use `cargo doc` WITHOUT `--open` flag to prevent launching GUI programs
+  - Never attempt to open HTML files with system defaults
+  - View generated docs by navigating directly to `target/doc/` paths
+  - Run all documentation generation in CI-friendly headless mode
 
 ### 4. QA Agent
 - **Scope**: Testing harness, regression coverage, CI guardrails.
@@ -124,6 +129,10 @@ cargo clippy --all-targets --all-features -- -D warnings
 
 # Run tests (once implemented)
 cargo test --all
+
+# Generate documentation (headless, no GUI)
+cargo doc --no-deps
+# View docs manually at: target/doc/openai_ergonomic/index.html
 
 # Run a specific example (placeholder)
 cargo run --example responses_quickstart


### PR DESCRIPTION
## Summary
- Updated AGENTS.md to ensure Docs Agent operates in headless mode
- Added explicit instructions to avoid launching GUI programs like LibreOffice
- Added headless documentation generation commands to Quick Commands section

## Problem
The Docs Agent was running `cargo doc --open` which attempted to open HTML files with system default programs. On some systems, this incorrectly launched LibreOffice Writer instead of a web browser, causing unnecessary GUI processes.

## Solution
- Docs Agent now explicitly instructed to use `cargo doc` without `--open` flag
- Added guidelines for CI-friendly headless documentation generation
- Updated Quick Commands with proper headless doc generation example

## Test plan
- [ ] Run `cargo doc --no-deps` to generate docs without opening browser
- [ ] Verify no GUI programs are launched
- [ ] Documentation still generates correctly at `target/doc/`