### PR TITLE
fix: resolve clippy collapsible_match warning

### DIFF
--- a/tests/error_handling_tests.rs
+++ b/tests/error_handling_tests.rs
@@ -338,12 +338,9 @@ fn test_error_response_fixtures() {
             "invalid_api_key" => {
                 assert!(message.contains("API key") || message.contains("api key"));
             }
-            "invalid_request_error" => {
-                // Should have param field for validation errors
-                if error.get("param").is_some() {
-                    let param = error.get("param").unwrap().as_str().unwrap();
-                    assert!(!param.is_empty());
-                }
+            "invalid_request_error" if error.get("param").is_some() => {
+                let param = error.get("param").unwrap().as_str().unwrap();
+                assert!(!param.is_empty());
             }
             "server_error" => {
                 assert!(message.contains("server") || message.contains("Server"));

--- a/tests/streaming_integration_tests.rs
+++ b/tests/streaming_integration_tests.rs
@@ -463,8 +463,8 @@ async fn test_streaming_performance() {
     let duration = start.elapsed();
 
     assert!(
-        duration <= Duration::from_millis(1000),
-        "large_streaming_response took {:?} but should complete within 1000ms",
+        duration <= Duration::from_secs(1),
+        "large_streaming_response took {:?} but should complete within 1s",
         duration
     );
 


### PR DESCRIPTION
Collapse nested `if` into match guard as suggested by clippy. Unblocks the renovate automerge PR.